### PR TITLE
Add unit declarator to module declarations

### DIFF
--- a/lib/Operator/feq.pm6
+++ b/lib/Operator/feq.pm6
@@ -1,4 +1,4 @@
-module Operator::feq;
+unit module Operator::feq;
 
 role Operator::feq {
   method compare($a, $b) returns Int { ... }


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class`, `role` or `grammar` declarations (unless it uses a
block).  Code still using the old blockless semicolon form will throw a
warning. This commit stops the warning from appearing in the new Rakudo.
