### PR TITLE
Extra help in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,16 @@ See the tests for an example of how to extend/create custom comparison routines.
 
 Defaults: ```Text::Levenshtein::Damerau```
 
-Set this dynamic variable to control which library 'feq' uses
+Set this dynamic variable to control which library 'feq' uses.  Note that
+for the tests to run, the module `Text::Levenshtein::Damerau` must be
+installed.  If, upon running the tests, you receive this error:
+
+    Dynamic variable $*FEQLIB not found
+
+then you need to install `Text::Levenshtein::Damerau`, for instance via
+`panda`:
+
+    panda intstall Text::Levenshtein::Damerau
 
 ##```$*FEQTHRESHOLD```
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Provides ```feq``` operator for clean fuzzy string comparisons.
 
-Includes a precanned wrapper for Text::Levenshtein::Damerau (the wrapper uses just the Levenshtein algorithm by default)
+Includes a precanned wrapper for `Text::Levenshtein::Damerau` (the wrapper uses just the Levenshtein algorithm by default).
 
 #Usage
 


### PR DESCRIPTION
Add some text to the README to make the implicit dependency on `Text::Levenshtein::Damerau` more explicit, such that new user errors are more likely to be avoided.
